### PR TITLE
Add cli auth and adjust user api token handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ cloudendure api login
 or
 
 ```sh
-export CLOUDENDURE_TOKEN=<your_ce_api_token>
+export CLOUDENDURE_USER_API_TOKEN=<your_ce_user_api_token>
 export CLOUDENDURE_DESTINATION_ACCOUNT=<destination_aws_account_id>
 
 ce api login
@@ -69,7 +69,7 @@ cloudendure api login --user=<your_ce_user> --password=<your_ce_password>
 or
 
 ```sh
-ce api login --token=<your_ce_token>
+ce api login --token=<your_ce_user_api_token>
 ```
 
 Logging in for the first time will generate the `~/.cloudendure.yml` file.

--- a/cloudendure/cloudendure.py
+++ b/cloudendure/cloudendure.py
@@ -29,14 +29,23 @@ AWS_REGION: str = os.environ.get("AWS_REGION", "")
 class CloudEndure:
     """Define the CloudEndure general object."""
 
-    def __init__(self, project_name: str = "", dry_run: bool = False) -> None:
+    def __init__(
+        self,
+        project_name: str = "",
+        dry_run: bool = False,
+        username: str = "",
+        password: str = "",
+        token: str = "",
+    ) -> None:
         """Initialize the CloudEndure object.
 
         This entrypoint is primarily for use with the CLI.
 
         """
-        self.config: CloudEndureConfig = CloudEndureConfig()
-        self.api: CloudEndureAPI = CloudEndureAPI()
+        self.config: CloudEndureConfig = CloudEndureConfig(
+            username=username, password=password, token=token
+        )
+        self.api: CloudEndureAPI = CloudEndureAPI(self.config)
         self.is_authenticated = self.api.login()
 
         # Determine the active project ID.

--- a/cloudendure/config.py
+++ b/cloudendure/config.py
@@ -17,7 +17,9 @@ logger.setLevel(getattr(logging, LOG_LEVEL))
 class CloudEndureConfig:
     """Define the CloudEndure Config object."""
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(
+        self, username: str = "", password: str = "", token: str = "", *args, **kwargs
+    ) -> None:
         """Initialize the Environment."""
         logger.info("Initializing the CloudEndure Configuration")
         _config_path: str = os.environ.get(
@@ -25,6 +27,9 @@ class CloudEndureConfig:
         )
         if _config_path.startswith("~"):
             self.config_path = os.path.expanduser(_config_path)
+
+        # Handle CloudEndure CLI input credentials.
+        self.cli = {"username": username, "password": password, "user_api_token": token}
 
         _config: PosixPath = Path(self.config_path)
         if not _config.exists():
@@ -40,6 +45,7 @@ class CloudEndureConfig:
                     "username": "",
                     "password": "",
                     "token": "",
+                    "user_api_token": "",
                     "session_cookie": "",
                     "project_name": "",
                     "project_id": "",
@@ -112,7 +118,11 @@ class CloudEndureConfig:
         """Update the configuration."""
         self.yaml_config_contents: Dict[str, Any] = self.read_yaml_config()
         self.env_config = self.get_env_vars()
-        self.active_config = {**self.yaml_config_contents, **self.env_config}
+        self.active_config = {
+            **self.yaml_config_contents,
+            **self.env_config,
+            **self.cli,
+        }
 
     def update_token(self, token: str) -> bool:
         """Update the CloudEndure token.


### PR DESCRIPTION
The goal of this PR is to implement CLI based authentication to take precedence over env and yaml configuration.

Additionally, this PR adjusts authentication to give precedence to: `userApiToken` over username and password to perform API login.

Fixes: #63, #66