### PR TITLE
Add base bravado cursor

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -44,6 +44,7 @@ certifi = "*"
 python-dateutil = "*"
 setuptools = "*"
 urllib3 = "*"
+bravado = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "acdee86ec88488d952837f6b81bf5cfee1caf4203f6c1f6e10dbc21ecc35b621"
+            "sha256": "038eff5f2eee335d79fa60563d57eb74f11cd8c620694ae852954b01fcc27a74"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,13 @@
         ]
     },
     "default": {
+        "attrs": {
+            "hashes": [
+                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
+                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
+            ],
+            "version": "==19.1.0"
+        },
         "boto3": {
             "hashes": [
                 "sha256:48624b5ae02c8bca674627099b98e578a8ab8836e04c7f8f555c8566836681cd",
@@ -30,6 +37,21 @@
                 "sha256:f0e436c9402ca2c0ec10cb6f82b385e5d7e05b159cd3dac330e21a822d2af8b0"
             ],
             "version": "==1.12.222"
+        },
+        "bravado": {
+            "hashes": [
+                "sha256:0020c6426affaf39b8d8e9d75fba6abb1271248440ee8fa62253d32dd3a4ea31",
+                "sha256:0fd1bd1d24dd246846c931edfcd04617e83689a91dc6b415db28384568bf8961"
+            ],
+            "index": "pypi",
+            "version": "==10.4.1"
+        },
+        "bravado-core": {
+            "hashes": [
+                "sha256:1565fef3777f496d4a3bf2732d4c5e97fdf9d3b8c16edfb1ae168d79a6cdf87e",
+                "sha256:6a8421ab101eb731dec8afadac0907d491f4307697b357c9898525a4d75078c7"
+            ],
+            "version": "==5.13.2"
         },
         "certifi": {
             "hashes": [
@@ -79,6 +101,49 @@
             ],
             "version": "==0.9.4"
         },
+        "jsonpointer": {
+            "hashes": [
+                "sha256:c192ba86648e05fdae4f08a17ec25180a9aef5008d973407b581798a83975362",
+                "sha256:ff379fa021d1b81ab539f5ec467c7745beb1a5671463f9dcc2b2d458bd361c1e"
+            ],
+            "version": "==2.0"
+        },
+        "jsonref": {
+            "hashes": [
+                "sha256:b1e82fa0b62e2c2796a13e5401fe51790b248f6d9bf9d7212a3e31a3501b291f",
+                "sha256:f3c45b121cf6257eafabdc3a8008763aed1cd7da06dbabc59a9e4d2a5e4e6697"
+            ],
+            "version": "==0.2"
+        },
+        "jsonschema": {
+            "extras": [
+                "format"
+            ],
+            "hashes": [
+                "sha256:5f9c0a719ca2ce14c5de2fd350a64fd2d13e8539db29836a86adc990bb1a068f",
+                "sha256:8d4a2b7b6c2237e0199c8ea1a6d3e05bf118e289ae2b9d7ba444182a2959560d"
+            ],
+            "version": "==3.0.2"
+        },
+        "monotonic": {
+            "hashes": [
+                "sha256:23953d55076df038541e648a53676fb24980f7a1be290cdda21300b3bc21dfb0",
+                "sha256:552a91f381532e33cbd07c6a2655a21908088962bb8fa7239ecbcc6ad1140cc7"
+            ],
+            "version": "==1.5"
+        },
+        "msgpack-python": {
+            "hashes": [
+                "sha256:378cc8a6d3545b532dfd149da715abae4fda2a3adb6d74e525d0d5e51f46909b"
+            ],
+            "version": "==0.5.6"
+        },
+        "pyrsistent": {
+            "hashes": [
+                "sha256:34b47fa169d6006b32e99d4b3c4031f155e6e68ebcc107d6454852e8e0ee6533"
+            ],
+            "version": "==0.15.4"
+        },
         "python-dateutil": {
             "hashes": [
                 "sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb",
@@ -86,6 +151,31 @@
             ],
             "index": "pypi",
             "version": "==2.8.0"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:26c0b32e437e54a18161324a2fca3c4b9846b74a8dccddd843113109e1116b32",
+                "sha256:c894d57500a4cd2d5c71114aaab77dbab5eabd9022308ce5ac9bb93a60a6f0c7"
+            ],
+            "version": "==2019.2"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:0113bc0ec2ad727182326b61326afa3d1d8280ae1122493553fd6f4397f33df9",
+                "sha256:01adf0b6c6f61bd11af6e10ca52b7d4057dd0be0343eb9283c878cf3af56aee4",
+                "sha256:5124373960b0b3f4aa7df1707e63e9f109b5263eca5976c66e08b1c552d4eaf8",
+                "sha256:5ca4f10adbddae56d824b2c09668e91219bb178a1eee1faa56af6f99f11bf696",
+                "sha256:7907be34ffa3c5a32b60b95f4d95ea25361c951383a894fec31be7252b2b6f34",
+                "sha256:7ec9b2a4ed5cad025c2278a1e6a19c011c80a3caaac804fd2d329e9cc2c287c9",
+                "sha256:87ae4c829bb25b9fe99cf71fbb2140c448f534e24c998cc60f39ae4f94396a73",
+                "sha256:9de9919becc9cc2ff03637872a440195ac4241c80536632fffeb6a1e25a74299",
+                "sha256:a5a85b10e450c66b49f98846937e8cfca1db3127a9d5d1e31ca45c3d0bef4c5b",
+                "sha256:b0997827b4f6a7c286c01c5f60384d218dca4ed7d9efa945c3e1aa623d5709ae",
+                "sha256:b631ef96d3222e62861443cc89d6563ba3eeb816eeb96b2629345ab795e53681",
+                "sha256:bf47c0607522fdbca6c9e817a6e81b08491de50f3766a7a0e6a5be7905961b41",
+                "sha256:f81025eddd0327c7d4cfe9b62cf33190e1e736cc6e97502b3ec425f574b3e7a8"
+            ],
+            "version": "==5.1.2"
         },
         "requests": {
             "hashes": [
@@ -95,12 +185,36 @@
             "index": "pypi",
             "version": "==2.22.0"
         },
+        "rfc3987": {
+            "hashes": [
+                "sha256:10702b1e51e5658843460b189b185c0366d2cf4cff716f13111b0ea9fd2dce53",
+                "sha256:d3c4d257a560d544e9826b38bc81db676890c79ab9d7ac92b39c7a253d5ca733"
+            ],
+            "version": "==1.3.8"
+        },
         "s3transfer": {
             "hashes": [
                 "sha256:6efc926738a3cd576c2a79725fed9afde92378aa5c6a957e3af010cb019fac9d",
                 "sha256:b780f2411b824cb541dbcd2c713d0cb61c7d1bcadae204cdddda2b35cef493ba"
             ],
             "version": "==0.2.1"
+        },
+        "simplejson": {
+            "hashes": [
+                "sha256:067a7177ddfa32e1483ba5169ebea1bc2ea27f224853211ca669325648ca5642",
+                "sha256:2fc546e6af49fb45b93bbe878dea4c48edc34083729c0abd09981fe55bdf7f91",
+                "sha256:354fa32b02885e6dae925f1b5bbf842c333c1e11ea5453ddd67309dc31fdb40a",
+                "sha256:37e685986cf6f8144607f90340cff72d36acf654f3653a6c47b84c5c38d00df7",
+                "sha256:3af610ee72efbe644e19d5eaad575c73fb83026192114e5f6719f4901097fce2",
+                "sha256:3b919fc9cf508f13b929a9b274c40786036b31ad28657819b3b9ba44ba651f50",
+                "sha256:3dd289368bbd064974d9a5961101f080e939cbe051e6689a193c99fb6e9ac89b",
+                "sha256:6c3258ffff58712818a233b9737fe4be943d306c40cf63d14ddc82ba563f483a",
+                "sha256:75e3f0b12c28945c08f54350d91e624f8dd580ab74fd4f1bbea54bc6b0165610",
+                "sha256:b1f329139ba647a9548aa05fb95d046b4a677643070dc2afc05fa2e975d09ca5",
+                "sha256:ee9625fc8ee164902dfbb0ff932b26df112da9f871c32f0f9c1bcf20c350fe2a",
+                "sha256:fb2530b53c28f0d4d84990e945c2ebb470edb469d63e389bf02ff409012fe7c5"
+            ],
+            "version": "==3.16.0"
         },
         "six": {
             "hashes": [
@@ -110,11 +224,32 @@
             "index": "pypi",
             "version": "==1.12.0"
         },
+        "strict-rfc3339": {
+            "hashes": [
+                "sha256:5cad17bedfc3af57b399db0fed32771f18fc54bbd917e85546088607ac5e1277"
+            ],
+            "version": "==0.7"
+        },
+        "swagger-spec-validator": {
+            "hashes": [
+                "sha256:57e29feb3aa921a9fb98bd70af148746b27c77d3207266f5571cebcce211e685",
+                "sha256:62ef22eca3f429d93fddda5d793d2a1a9057d3732e7a14606e641805326ae4a6"
+            ],
+            "version": "==2.4.3"
+        },
         "termcolor": {
             "hashes": [
                 "sha256:1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b"
             ],
             "version": "==1.1.0"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:2ed632b30bb54fc3941c382decfd0ee4148f5c591651c9272473fea2c6397d95",
+                "sha256:b1edbbf0652660e32ae780ac9433f4231e7339c7f9a8057d0f042fcbcea49b87",
+                "sha256:d8179012ec2c620d3791ca6fe2bf7979d979acdbef1fca0bc56b37411db682ed"
+            ],
+            "version": "==3.7.4"
         },
         "urllib3": {
             "hashes": [
@@ -123,6 +258,13 @@
             ],
             "index": "pypi",
             "version": "==1.25.3"
+        },
+        "webcolors": {
+            "hashes": [
+                "sha256:18c091bd4bd75efd1e9f84f5eca4a54f6e6485eaa3967d2a55700835a1b1c418",
+                "sha256:771adfb75a8d9189724de748b2e9564edf64104726bff0c4f6e11d15635e6517"
+            ],
+            "version": "==1.9.1"
         }
     },
     "develop": {
@@ -484,6 +626,9 @@
             "version": "==2.0"
         },
         "jsonschema": {
+            "extras": [
+                "format"
+            ],
             "hashes": [
                 "sha256:5f9c0a719ca2ce14c5de2fd350a64fd2d13e8539db29836a86adc990bb1a068f",
                 "sha256:8d4a2b7b6c2237e0199c8ea1a6d3e05bf118e289ae2b9d7ba444182a2959560d"

--- a/cloudendure/client.py
+++ b/cloudendure/client.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+"""Define the CloudEndure API client related logic."""
+from __future__ import annotations
+
+from bravado.client import SwaggerClient
+from bravado.requests_client import RequestsClient as requests_client
+
+from .config import CloudEndureConfig
+
+
+class CloudEndureClient:
+    """Define the CloudEndure API client."""
+
+    def __init__(
+        self: CloudEndureClient, config: CloudEndureConfig, project_id: str = ""
+    ) -> None:
+        """Initialize the CloudEndure API client."""
+        self.config = config
+        self.project_id = project_id
+        self.swagger_api_url = self.config.active_config.get(
+            "swagger_api_json_url", "https://console.cloudendure.com/api_doc/apis.json"
+        )
+        self.http_client = requests_client()
+        self.http_client.set_api_key(
+            "console.cloudendure.com",
+            self.config.active_config.get("token", ""),
+            param_name="X-XSRF-TOKEN",
+            param_in="header",
+        )
+        self.cursor = SwaggerClient.from_url(
+            self.swagger_api_url, http_client=self.http_client
+        )

--- a/cloudendure/cloudendure.py
+++ b/cloudendure/cloudendure.py
@@ -15,6 +15,7 @@ from botocore.exceptions import ClientError
 from requests.models import Response
 
 from .api import CloudEndureAPI
+from .client import CloudEndureClient
 from .config import CloudEndureConfig
 from .events import Event, EventHandler
 from .exceptions import CloudEndureHTTPException, CloudEndureMisconfigured
@@ -59,6 +60,9 @@ class CloudEndure:
         if not self.project_id or (project_name and project_name != self.project_name):
             self.project_id: str = self.get_project_id(project_name=self.project_name)
 
+        self.client: CloudEndureClient = CloudEndureClient(
+            self.config, project_id=self.project_id
+        )
         self.dry_run = dry_run
         self.event_handler: EventHandler = EventHandler()
         self.destination_account: str = self.config.active_config.get(

--- a/cloudendure/config.py
+++ b/cloudendure/config.py
@@ -37,6 +37,7 @@ class CloudEndureConfig:
         "destination_role": "",
         "disk_type": "SSD",
         "public_ip": "DONT_ALLOCATE",
+        "swagger_api_json_url": "https://console.cloudendure.com/api_doc/apis.json",
     }
 
     def __init__(

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ EXTRAS: Dict[str, List[str]] = {
         "bandit",
         "mypy",
         "twine",
+        "moto",
     ]
 }
 


### PR DESCRIPTION
The goal of this PR is to implement an API cursor that can be used to traverse the CloudEndure API, based on the swagger spec manifest.