### PR TITLE
Update servicenow lambda refs to conform to generic status update

### DIFF
--- a/step/cloudwatch.tf
+++ b/step/cloudwatch.tf
@@ -31,6 +31,6 @@ resource "aws_cloudwatch_event_target" "rehost_migration_target" {
 
 resource "aws_lambda_event_source_mapping" "event_source_mapping" {
   event_source_arn = "${aws_sqs_queue.event_queue.arn}"
-  function_name    = "${aws_lambda_function.lambda_update_servicenow.arn}"
+  function_name    = "${aws_lambda_function.lambda_update_status.arn}"
   batch_size       = 1
 }

--- a/step/lambdas.tf
+++ b/step/lambdas.tf
@@ -149,11 +149,11 @@ resource "aws_lambda_function" "lambda_image_cleanup" {
   }
 }
 
-resource "aws_lambda_function" "lambda_update_servicenow" {
+resource "aws_lambda_function" "lambda_update_status" {
   filename         = "lambdas.zip"
-  function_name    = "ce-update-servicenow"
+  function_name    = "ce-update-status"
   role             = "${aws_iam_role.iam_for_lambda.arn}"
-  handler          = "update_servicenow.lambda_handler"
+  handler          = "update_status.lambda_handler"
   source_code_hash = "${data.archive_file.lambdas.output_base64sha256}"
   runtime          = "python3.7"
   depends_on       = ["data.archive_file.lambdas"]

--- a/step/lambdas/update_status.py
+++ b/step/lambdas/update_status.py
@@ -8,15 +8,15 @@ import os
 
 import boto3
 
-# from typing import Any, Dict, List
+from typing import Any, Dict
 
 
-print("Loading function update_servicenow")
+print("Loading function update_status")
 
 
 def lambda_handler(event: Dict[str, Any], context: Any) -> bool:
     """Handle signaling and entry into the AWS Lambda."""
-    print("Received event: " + json.dumps(event, indent=2))
+    print("Received event: ", json.dumps(event, indent=2))
 
     for record in event["Records"]:
         payload = record["body"]


### PR DESCRIPTION
The goal of this PR is to update `servicenow` references to use generic: `status update` as well as resolve `typing` references before assignment in status update lambda.