### PR TITLE
change to using describe_instances vs _status.  linted.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ AUTHOR: str = "Mark Beacom, Tom Warnock"
 REQUIRES_PYTHON: str = ">=3.7.0"
 VERSION: str = "0.1.5"
 
-REQUIRED: List[str] = ["requests", "boto3", "fire", ]
+REQUIRED: List[str] = ["requests", "boto3", "fire"]
 EXTRAS: Dict[str, List[str]] = {
     "test": [
         "coverage",

--- a/step/lambdas/update_status.py
+++ b/step/lambdas/update_status.py
@@ -5,11 +5,9 @@ from __future__ import annotations
 
 import json
 import os
-
-import boto3
-
 from typing import Any, Dict
 
+import boto3
 
 print("Loading function update_status")
 


### PR DESCRIPTION
Fixing a bug where you will get an error if an instance is stopped and you try to check its status.  