### PR TITLE
Add check for sg/subnet existance in config and patch privateIPAction

### DIFF
--- a/cloudendure/cloudendure.py
+++ b/cloudendure/cloudendure.py
@@ -71,6 +71,11 @@ class CloudEndure:
             "destination_role", ""
         )
         self.subnet_id: str = self.config.active_config.get("subnet_id", "")
+        self.private_ip_action: str = self.config.active_config.get(
+            "private_ip_action", ""
+        )
+        if self.subnet_id and not self.private_ip_action:
+            self.private_ip_action = "CREATE_NEW"
         self.security_group_id: str = self.config.active_config.get(
             "security_group_id", ""
         )
@@ -494,6 +499,7 @@ class CloudEndure:
                 if self.subnet_id:
                     # Update launch subnets and SG IDs
                     blueprint["subnetIDs"] = [self.subnet_id]
+                if self.private_ip_action:
                     blueprint["privateIPAction"] = "CREATE_NEW"
                 if self.security_group_id:
                     blueprint["securityGroupIDs"] = [self.security_group_id]

--- a/cloudendure/cloudendure.py
+++ b/cloudendure/cloudendure.py
@@ -491,9 +491,12 @@ class CloudEndure:
                     )
                 blueprint["disks"] = new_disks
 
-                # Update launch subnets and SG IDs
-                blueprint["subnetIDs"] = [self.subnet_id]
-                blueprint["securityGroupIDs"] = [self.security_group_id]
+                if self.subnet_id:
+                    # Update launch subnets and SG IDs
+                    blueprint["subnetIDs"] = [self.subnet_id]
+                    blueprint["privateIPAction"] = "CREATE_NEW"
+                if self.security_group_id:
+                    blueprint["securityGroupIDs"] = [self.security_group_id]
 
                 # Update machine tags
                 blueprint["tags"] = [

--- a/cloudendure/cloudendure.py
+++ b/cloudendure/cloudendure.py
@@ -500,7 +500,7 @@ class CloudEndure:
                     # Update launch subnets and SG IDs
                     blueprint["subnetIDs"] = [self.subnet_id]
                 if self.private_ip_action:
-                    blueprint["privateIPAction"] = "CREATE_NEW"
+                    blueprint["privateIPAction"] = self.private_ip_action
                 if self.security_group_id:
                     blueprint["securityGroupIDs"] = [self.security_group_id]
 

--- a/cloudendure/config.py
+++ b/cloudendure/config.py
@@ -37,6 +37,7 @@ class CloudEndureConfig:
         "destination_role": "",
         "subnet_id": "",
         "security_group_id": "",
+        "private_ip_action": "",
         "disk_type": "SSD",
         "public_ip": "DONT_ALLOCATE",
     }


### PR DESCRIPTION
The goal of this PR is to ensure we're not passing an empty string for unset subnet_id and security_group values, as well as patching the `privateIPAction` to `CREATE_NEW` if a subnet is provided.