### PR TITLE
Adjust setup.py to conform to pipfile

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ MAINTAINER: str = "Evan Lucchesi Leon,Nick Selpa"
 REQUIRES_PYTHON: str = ">=3.7.0"
 VERSION: str = os.environ.get("CLOUDENDURE_CLIENT_VERSION", "")
 
-REQUIRED: List[str] = ["requests", "boto3", "fire"]
+REQUIRED: List[str] = ["requests", "boto3", "fire", "cookiecutter"]
 EXTRAS: Dict[str, List[str]] = {
     "test": [
         "coverage",


### PR DESCRIPTION
The goal of this PR is to resolve a bug while attempting to `pip install cloudendure` resulting in the output detailed in #99 

The package installation process should be simplified with the introduction of Poetry over legacy venv and package handling.