### PR TITLE
Adjust Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,16 @@
-FROM python:3.7-slim-buster
+FROM python:3.8-slim
 
 WORKDIR /app
 
-ARG SYSTEM_PACKAGES="make"
-
-RUN apt-get -qq update
-RUN apt-get -qq install apt-utils
-RUN apt-get -qq upgrade
-RUN apt-get -qq install ${SYSTEM_PACKAGES}
+RUN apt-get -qq update && \
+    apt-get -qq install make
 
 COPY . /app
 
-RUN pip install --upgrade pip
-RUN pip install --upgrade wheel setuptools twine
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
-RUN source $HOME/.poetry/env
-RUN poetry install
+RUN pip install --upgrade pip wheel setuptools poetry
+
+RUN poetry config virtualenvs.create false && \
+    poetry install --no-interaction --no-ansi
 
 RUN apt-get clean autoclean && \
     apt-get autoremove --yes && \

--- a/Dockerfile-py39
+++ b/Dockerfile-py39
@@ -1,19 +1,16 @@
-FROM python:3.8-rc-slim-buster
+FROM python:3.9-rc
 
-ARG SYSTEM_PACKAGES="make"
+WORKDIR /app
 
-RUN apt-get -qq update
-RUN apt-get -qq install apt-utils
-RUN apt-get -qq upgrade
-RUN apt-get -qq install ${SYSTEM_PACKAGES}
+RUN apt-get -qq update && \
+    apt-get -qq install make
 
 COPY . /app
 
-RUN pip install --upgrade pip
-RUN pip install --upgrade wheel setuptools twine
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
-RUN source $HOME/.poetry/env
-RUN poetry install
+RUN pip install --upgrade pip wheel setuptools poetry
+
+RUN poetry config virtualenvs.create false && \
+    poetry install --no-interaction --no-ansi
 
 RUN apt-get clean autoclean && \
     apt-get autoremove --yes && \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,8 @@
 name = "cloudendure"
 version = "0.2.0"
 description = "Python wrapper and CLI for CloudEndure"
-authors = ["Mark Beacom <mbeacom@2ndwatch.com>"]
+authors = ["Mark Beacom <mark@markbeacom.com>", "Tom Warnock <twarnock@2ndwatch.com>"]
+maintainers = ["Evan Lucchesi <evan@2ndwatch.com>", "Nick Selpa <nselpa@2ndwatch.com>"]
 include = [
     "CHANGELOG.md",
     "CODE_OF_CONDUCT.md",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,84 @@
+[tool:pytest]
+norecursedirs =
+    .git
+    venv
+python_files =
+    test_*.py
+    *_test.py
+    tests.py
+addopts =
+    -rf
+    --isort
+    --cov
+
+[flake8]
+max-line-length = 120
+exclude = .tox,.git
+
+[pycodestyle]
+max-line-length = 120
+exclude = .tox,.git
+
+[pylint]
+max-line-length = 120
+exclude = .tox,.git
+
+[coverage:run]
+branch = True
+source =
+    app
+omit =
+    *.eggs*
+    *tests*
+    */__init__.py
+
+[coverage:report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:
+
+ignore_errors = True
+
+[coverage:html]
+directory = coverage_html_report
+
+[isort]
+line_length = 120
+multi_line_output = 5
+include_trailing_comma = True
+known_future_library = future
+known_third_party = boto3,botocore,fire,pytest,requests,urllib3,six,yaml
+known_first_party = cloudendure_api,api,cloudendure,config,events,exceptions,models,templates,utils
+default_section = THIRDPARTY
+indent = '    '
+sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+skip=cloudendure/cloudendure_api
+
+[yapf]
+based_on_style = pep8
+column_limit = 120
+indent_width = 4
+spaces_before_comment = 2
+ALLOW_SPLIT_BEFORE_DICT_VALUE = false
+DEDENT_CLOSING_BRACKETS = true
+EACH_DICT_ENTRY_ON_SEPARATE_LINE = true
+COALESCE_BRACKETS = true
+USE_TABS = false
+ALLOW_MULTILINE_LAMBDAS = true
+BLANK_LINE_BEFORE_NESTED_CLASS_OR_DEF = true
+INDENT_DICTIONARY_VALUE = true
+SPLIT_BEFORE_EXPRESSION_AFTER_OPENING_PAREN = true
+DISABLE_ENDING_COMMA_HEURISTIC = true


### PR DESCRIPTION
The goal of this PR is to adjust the docker image manifests to accommodate the poetry changes from #98.

Additionally, this PR re-introduces the `setup.cfg` file that is still needed by some packages. i.e. `black`